### PR TITLE
Update retrieve_ghcn.py

### DIFF
--- a/nmc_met_io/retrieve_ghcn.py
+++ b/nmc_met_io/retrieve_ghcn.py
@@ -206,9 +206,9 @@ def _create_DataFrame_1stn(filename, verbose=False):
                 warnings.append(element_tmp+\
                         ' values have been divided by ten' + \
                         ' as specified by readme.txt')
-                value[i] = np.float(val_tmp) / 10.
+                value[i] = np.float64(val_tmp) / 10.
             else:
-                value[i] = np.float(val_tmp)
+                value[i] = np.float64(val_tmp)
             
             mflag.append(line[ cols[1] ])
             qflag.append(line[ cols[2] ])


### PR DESCRIPTION
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. The aliases was originally deprecated in NumPy 1.20