### PR TITLE
Update retrieve_cassandraDB.py

### DIFF
--- a/nmc_met_io/retrieve_cassandraDB.py
+++ b/nmc_met_io/retrieve_cassandraDB.py
@@ -1571,8 +1571,8 @@ def get_swan_radar(directory, filename=None, suffix="*.000", scale=[0.1, 0],
             nlon = head_info['XNumGrids'][0].astype(np.int64)
             nlat = head_info['YNumGrids'][0].astype(np.int64)
             nlev = head_info['ZNumGrids'][0].astype(np.int64)
-            dlon = head_info['XReso'][0].astype(np.float)
-            dlat = head_info['YReso'][0].astype(np.float)
+            dlon = head_info['XReso'][0].astype(np.float64)
+            dlat = head_info['YReso'][0].astype(np.float64)
             lat = head_info['StartLat'][0] - np.arange(nlat)*dlat - dlat/2.0
             lon = head_info['StartLon'][0] + np.arange(nlon)*dlon - dlon/2.0
             level = head_info['ZhighGrids'][0][0:nlev]


### PR DESCRIPTION
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20